### PR TITLE
add monochrome icon

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/app_icon.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/app_icon.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/app_icon_background" />
     <foreground android:drawable="@mipmap/app_icon_foreground" />
+    <monochrome android:drawable="@mipmap/app_icon_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
Added monochrome icon, to support user theming of app icons

https://developer.android.com/develop/ui/views/launch/icon_design_adaptive#add-to-your-app

Before:
<img width="257" alt="image" src="https://github.com/airmessage/airmessage-android/assets/13486734/4a2e9ce5-764a-4027-8134-0342cf4e29f4">

After:
<img width="257" alt="image" src="https://github.com/airmessage/airmessage-android/assets/13486734/05853fbf-d67b-4eb8-a7d3-04faf09a2c7b">
